### PR TITLE
Feat/POST

### DIFF
--- a/CM4/Core/Inc/steering/fsm.h
+++ b/CM4/Core/Inc/steering/fsm.h
@@ -65,17 +65,10 @@ typedef void transition_func_t(fsm_state_data_t *data);
 /*** USER CODE BEGIN TYPES ***/
 
 /*!
- * \brief Callback definition for to retrieve the currect system time.
- *
- * \retval current system tick
+ * \brief This struct contains the data needed by the FSM to operate and call other modules successfully. It is passed as an argument to all state and transition functions.
  */
-typedef uint32_t (*get_system_tick)(void);
-
-// TODO: this is temporary, until POST is properly implemented
 struct FsmData {
-    void (*critical_section_callback)(void);
-    leds_transmit_callback leds_transmit;
-    get_system_tick get_tick;
+    uint32_t tick; /*!< Current tick. */
 };
 
 /*** USER CODE END TYPES ***/

--- a/CM4/Core/Inc/steering/inputs-api.h
+++ b/CM4/Core/Inc/steering/inputs-api.h
@@ -23,7 +23,7 @@
  * \retval INPUTS_RC_ERROR if there was an error during initialization
  */
 enum InputsReturnCode inputs_api_init(
-    void (*critical_section_callback)(void),
+    ipc_critical_section_callback critical_section_callback,
     inputs_notify_callback notify_callback,
     inputs_action_callback action_callback);
 

--- a/CM4/Core/Inc/steering/inputs.h
+++ b/CM4/Core/Inc/steering/inputs.h
@@ -11,6 +11,7 @@
 #define INPUTS_H
 
 #include "inputs-shared.h"
+#include "ipc.h"
 #include <stdint.h>
 #include <stdbool.h>
 
@@ -60,7 +61,7 @@ struct InputsKnobHandler {
  * \retval true if the event was handled successfully
  * \retval false if there was an error notifying the event
  */
-typedef bool (*inputs_notify_callback)(struct InputsSharedEvent ev, void (*critical_section_callback)(void));
+typedef bool (*inputs_notify_callback)(struct InputsSharedEvent ev, ipc_critical_section_callback critical_section_callback);
 
 /*!
  * \brief Callback definition for input actions
@@ -76,7 +77,7 @@ typedef enum InputsReturnCode (*inputs_action_callback)(struct InputsSharedEvent
  * \brief Main input handler structure
  */
 struct InputsHandler {
-    void (*critical_section_callback)(void); /*!< Callback to perform DMB after notifying CM7 */
+    ipc_critical_section_callback critical_section_callback; /*!< Callback to perform critical section operations for IPC */
 
     inputs_notify_callback notify_callback; /*!< Callback to notify CM7 about input events */
     inputs_action_callback action_callback; /*!< Callback to perform local actions on input */

--- a/CM4/Core/Inc/steering/post-api.h
+++ b/CM4/Core/Inc/steering/post-api.h
@@ -1,0 +1,27 @@
+/*!
+ * \file post-api.h
+ * \date 2026-04-01
+ * \authors Alessandro Bridi [ale.bridi15@gmail.com]
+ *
+ * \brief This file defines Power-On Self-Test (POST) functions for system diagnostics.
+ */
+
+#ifndef POST_API_H
+#define POST_API_H
+
+#include "post.h"
+
+/*!
+ * \brief Performs the Power-On Self-Test (POST) using the provided initialization data.
+ *
+ * This function initializes all the modules required by the steering wheel firmware.
+ *
+ * \param post_init_data Pointer to a structure containing the necessary initialization data for POST.
+ *
+ * \retval POST_RC_OK if POST completed successfully
+ * \retval POST_RC_ERROR_MINOR if POST encountered a minor error
+ * \retval POST_RC_ERROR_SEVERE if POST encountered a severe error
+ */
+enum PostReturnCode post_api_do_init(struct PostInitData *post_init_data);
+
+#endif // POST_API_H

--- a/CM4/Core/Inc/steering/post-api.h
+++ b/CM4/Core/Inc/steering/post-api.h
@@ -19,8 +19,7 @@
  * \param post_init_data Pointer to a structure containing the necessary initialization data for POST.
  *
  * \retval POST_RC_OK if POST completed successfully
- * \retval POST_RC_ERROR_MINOR if POST encountered a minor error
- * \retval POST_RC_ERROR_SEVERE if POST encountered a severe error
+ * \retval POST_RC_ERROR if POST encountered an error
  */
 enum PostReturnCode post_api_do_init(struct PostInitData *post_init_data);
 

--- a/CM4/Core/Inc/steering/post.h
+++ b/CM4/Core/Inc/steering/post.h
@@ -1,0 +1,26 @@
+/*!
+ * \file post.h
+ * \date 2026-04-01
+ * \authors Alessandro Bridi [ale.bridi15@gmail.com]
+ *
+ * \brief This file defines Power-On Self-Test (POST) structures for system diagnostics.
+ */
+
+#ifndef POST_H
+#define POST_H
+
+#include "leds.h"
+#include "ipc.h"
+
+enum PostReturnCode {
+    POST_RC_OK,           /*!< POST completed successfully. */
+    POST_RC_ERROR_MINOR,  /*!< POST encountered a minor error. */
+    POST_RC_ERROR_SEVERE, /*!< POST encountered a severe error. */
+};
+
+struct PostInitData {
+    ipc_critical_section_callback ipc_critical_section; /*!< Callback function required by leds module. */
+    leds_transmit_callback leds_transmit;               /*!< Callback function required by leds module. */
+};
+
+#endif // POST_H

--- a/CM4/Core/Inc/steering/post.h
+++ b/CM4/Core/Inc/steering/post.h
@@ -13,9 +13,8 @@
 #include "ipc.h"
 
 enum PostReturnCode {
-    POST_RC_OK,           /*!< POST completed successfully. */
-    POST_RC_ERROR_MINOR,  /*!< POST encountered a minor error. */
-    POST_RC_ERROR_SEVERE, /*!< POST encountered a severe error. */
+    POST_RC_OK,    /*!< POST completed successfully. */
+    POST_RC_ERROR, /*!< POST encountered an error. */
 };
 
 struct PostInitData {

--- a/CM4/Core/Src/main.c
+++ b/CM4/Core/Src/main.c
@@ -28,6 +28,7 @@
 /* USER CODE BEGIN Includes */
 
 #include "fsm.h"
+#include "post.h"
 
 /* USER CODE END Includes */
 
@@ -123,19 +124,22 @@ int main(void) {
     MX_TIM5_Init();
     /* USER CODE BEGIN 2 */
 
-    struct FsmData data = {
-        .critical_section_callback = __DMB,
-        .get_tick = HAL_GetTick,
+    struct PostInitData data = {
+        .ipc_critical_section = __DMB,
         .leds_transmit = tim_leds_transmit,
     };
+
+    current_state = fsm_run_state(current_state, &data);
+
+    struct FsmData fsm_data;
 
     /* USER CODE END 2 */
 
     /* Infinite loop */
     /* USER CODE BEGIN WHILE */
     while (1) {
-
-        current_state = fsm_run_state(current_state, &data);
+        fsm_data.tick = HAL_GetTick();
+        current_state = fsm_run_state(current_state, &fsm_data);
         /* USER CODE END WHILE */
 
         /* USER CODE BEGIN 3 */

--- a/CM4/Core/Src/steering/fsm.c
+++ b/CM4/Core/Src/steering/fsm.c
@@ -17,10 +17,9 @@ Functions and types have been generated with prefix "fsm_"
 
 /*** USER CODE BEGIN MACROS ***/
 
-#include "eagletrt-api.h"
 #include "inputs-api.h"
-#include "ipc-api.h"
 #include "leds-api.h"
+#include "post-api.h"
 
 /*** USER CODE END MACROS ***/
 
@@ -56,11 +55,6 @@ fsm_event_data_t *fsm_fired_event = NULL;
 
 /*** USER CODE BEGIN GLOBALS ***/
 
-EAGLETRT_STATIC enum InputsReturnCode input_action_noop(struct InputsSharedEvent ev) {
-    EAGLETRT_API_UNUSED(ev);
-    return INPUTS_RC_OK;
-}
-
 /*** USER CODE END GLOBALS ***/
 
 // Function to check if an event has fired
@@ -95,13 +89,9 @@ fsm_state_t fsm_do_init(fsm_state_data_t *data) {
 
     /*** USER CODE BEGIN DO_INIT ***/
 
-    struct FsmData *fsm_data = (struct FsmData *)data;
+    struct PostInitData *post_init_data = (struct PostInitData *)data;
 
-    if (inputs_api_init(fsm_data->critical_section_callback, ipc_api_push_event, input_action_noop) != INPUTS_RC_OK) {
-        next_state = FSM_STATE_ERROR;
-    }
-
-    if (leds_api_init(fsm_data->leds_transmit) != LEDS_RC_OK) {
+    if (post_api_do_init(post_init_data) != POST_RC_OK) {
         next_state = FSM_STATE_ERROR;
     }
 
@@ -125,9 +115,12 @@ fsm_state_t fsm_do_idle(fsm_state_data_t *data) {
 
     /*** USER CODE BEGIN DO_IDLE ***/
 
-    struct FsmData *fsm_data = (struct FsmData *)data;
-
-    if (inputs_api_poll_for_long_press(fsm_data->get_tick()) != INPUTS_RC_OK) {
+    if (data != NULL) {
+        struct FsmData *fsm_data = (struct FsmData *)data;
+        if (inputs_api_poll_for_long_press(fsm_data->tick) != INPUTS_RC_OK) {
+            next_state = FSM_STATE_ERROR;
+        }
+    } else {
         next_state = FSM_STATE_ERROR;
     }
 

--- a/CM4/Core/Src/steering/inputs-api.c
+++ b/CM4/Core/Src/steering/inputs-api.c
@@ -33,7 +33,7 @@ EAGLETRT_STATIC enum InputsReturnCode prv_inputs_dispatch(
 }
 
 enum InputsReturnCode inputs_api_init(
-    void (*critical_section_callback)(void),
+    ipc_critical_section_callback critical_section_callback,
     inputs_notify_callback notify_callback,
     inputs_action_callback action_callback) {
     if (notify_callback == NULL || action_callback == NULL) {

--- a/CM4/Core/Src/steering/post-api.c
+++ b/CM4/Core/Src/steering/post-api.c
@@ -1,0 +1,33 @@
+/*!
+ * \file post-api.c
+ * \date 2026-04-01
+ * \authors Alessandro Bridi [ale.bridi15@gmail.com]
+ *
+ * \brief This file defines Power-On Self-Test (POST) functions for system diagnostics.
+ */
+
+#include "post-api.h"
+#include "inputs-api.h"
+#include "ipc-api.h"
+#include "leds-api.h"
+#include "eagletrt-api.h"
+
+// THIS IS HERE AS A PLACEHOLDER, WILL BE CHANGED WITH UI MODULE IMPLEMENTATION
+EAGLETRT_STATIC enum InputsReturnCode input_action_noop(struct InputsSharedEvent ev) {
+    EAGLETRT_API_UNUSED(ev);
+    return INPUTS_RC_OK;
+}
+
+enum PostReturnCode post_api_do_init(struct PostInitData *post_init_data) {
+    enum PostReturnCode ret_code = POST_RC_OK;
+
+    if (inputs_api_init(post_init_data->ipc_critical_section, ipc_api_push_event, input_action_noop) != INPUTS_RC_OK) {
+        ret_code = POST_RC_ERROR_SEVERE;
+    }
+
+    if (leds_api_init(post_init_data->leds_transmit) != LEDS_RC_OK) {
+        ret_code = POST_RC_ERROR_SEVERE;
+    }
+
+    return ret_code;
+}

--- a/CM4/Core/Src/steering/post-api.c
+++ b/CM4/Core/Src/steering/post-api.c
@@ -22,11 +22,11 @@ enum PostReturnCode post_api_do_init(struct PostInitData *post_init_data) {
     enum PostReturnCode ret_code = POST_RC_OK;
 
     if (inputs_api_init(post_init_data->ipc_critical_section, ipc_api_push_event, input_action_noop) != INPUTS_RC_OK) {
-        ret_code = POST_RC_ERROR_SEVERE;
+        ret_code = POST_RC_ERROR;
     }
 
     if (leds_api_init(post_init_data->leds_transmit) != LEDS_RC_OK) {
-        ret_code = POST_RC_ERROR_SEVERE;
+        ret_code = POST_RC_ERROR;
     }
 
     return ret_code;

--- a/CM7/Core/Inc/steering/post-api.h
+++ b/CM7/Core/Inc/steering/post-api.h
@@ -1,0 +1,25 @@
+/*!
+ * \file post-api.h
+ * \date 2026-04-01
+ * \authors Alessandro Bridi [ale.bridi15@gmail.com]
+ *
+ * \brief This file defines Power-On Self-Test (POST) functions for system diagnostics.
+ */
+
+#ifndef POST_API_H
+#define POST_API_H
+
+#include "post.h"
+
+/*!
+ * \brief Performs the Power-On Self-Test (POST) using the provided initialization data.
+ *
+ * This function initializes all the modules required by the steering wheel firmware.
+ *
+ * \retval POST_RC_OK if POST completed successfully
+ * \retval POST_RC_ERROR_MINOR if POST encountered a minor error
+ * \retval POST_RC_ERROR_SEVERE if POST encountered a severe error
+ */
+enum PostReturnCode post_api_do_init(struct PostInitData *post_init_data);
+
+#endif // POST_API_H

--- a/CM7/Core/Inc/steering/post-api.h
+++ b/CM7/Core/Inc/steering/post-api.h
@@ -17,8 +17,7 @@
  * This function initializes all the modules required by the steering wheel firmware.
  *
  * \retval POST_RC_OK if POST completed successfully
- * \retval POST_RC_ERROR_MINOR if POST encountered a minor error
- * \retval POST_RC_ERROR_SEVERE if POST encountered a severe error
+ * \retval POST_RC_ERROR if POST encountered an error
  */
 enum PostReturnCode post_api_do_init(struct PostInitData *post_init_data);
 

--- a/CM7/Core/Inc/steering/post.h
+++ b/CM7/Core/Inc/steering/post.h
@@ -10,9 +10,8 @@
 #define POST_H
 
 enum PostReturnCode {
-    POST_RC_OK,           /*!< POST completed successfully. */
-    POST_RC_ERROR_MINOR,  /*!< POST encountered a minor error. */
-    POST_RC_ERROR_SEVERE, /*!< POST encountered a severe error. */
+    POST_RC_OK,    /*!< POST completed successfully. */
+    POST_RC_ERROR, /*!< POST encountered an error. */
 };
 
 struct PostInitData;

--- a/CM7/Core/Inc/steering/post.h
+++ b/CM7/Core/Inc/steering/post.h
@@ -1,0 +1,20 @@
+/*!
+ * \file post.h
+ * \date 2026-04-01
+ * \authors Alessandro Bridi [ale.bridi15@gmail.com]
+ *
+ * \brief This file defines Power-On Self-Test (POST) structures for system diagnostics.
+ */
+
+#ifndef POST_H
+#define POST_H
+
+enum PostReturnCode {
+    POST_RC_OK,           /*!< POST completed successfully. */
+    POST_RC_ERROR_MINOR,  /*!< POST encountered a minor error. */
+    POST_RC_ERROR_SEVERE, /*!< POST encountered a severe error. */
+};
+
+struct PostInitData;
+
+#endif // POST_H

--- a/CM7/Core/Src/steering/fsm.c
+++ b/CM7/Core/Src/steering/fsm.c
@@ -17,8 +17,7 @@ Functions and types have been generated with prefix "fsm_"
 
 /*** USER CODE BEGIN MACROS ***/
 
-#include "screen-api.h"
-#include "input-events-api.h"
+#include "post-api.h"
 
 /*** USER CODE END MACROS ***/
 
@@ -88,11 +87,7 @@ fsm_state_t fsm_do_init(fsm_state_data_t *data) {
 
     /*** USER CODE BEGIN DO_INIT ***/
 
-    if (input_events_api_init(
-            mock_input_event_button_event_callback,
-            mock_input_event_button_long_press_callback,
-            mock_input_event_button_release_callback,
-            mock_input_event_knob_rotation_callback) != INPUT_EVENTS_RC_OK) {
+    if (post_api_do_init(NULL) != POST_RC_OK) {
         next_state = FSM_STATE_ERROR;
     }
 

--- a/CM7/Core/Src/steering/post-api.c
+++ b/CM7/Core/Src/steering/post-api.c
@@ -18,7 +18,7 @@ enum PostReturnCode post_api_do_init(struct PostInitData *post_init_data) {
             mock_input_event_button_long_press_callback,
             mock_input_event_button_release_callback,
             mock_input_event_knob_rotation_callback) != INPUT_EVENTS_RC_OK) {
-        ret_code = POST_RC_ERROR_SEVERE;
+        ret_code = POST_RC_ERROR;
     }
 
     return ret_code;

--- a/CM7/Core/Src/steering/post-api.c
+++ b/CM7/Core/Src/steering/post-api.c
@@ -1,0 +1,25 @@
+/*!
+ * \file post-api.c
+ * \date 2026-04-01
+ * \authors Alessandro Bridi [ale.bridi15@gmail.com]
+ *
+ * \brief This file defines Power-On Self-Test (POST) functions for system diagnostics.
+ */
+
+#include "post-api.h"
+#include "input-events-api.h"
+#include "screen-api.h"
+
+enum PostReturnCode post_api_do_init(struct PostInitData *post_init_data) {
+    enum PostReturnCode ret_code = POST_RC_OK;
+
+    if (input_events_api_init(
+            mock_input_event_button_event_callback,
+            mock_input_event_button_long_press_callback,
+            mock_input_event_button_release_callback,
+            mock_input_event_knob_rotation_callback) != INPUT_EVENTS_RC_OK) {
+        ret_code = POST_RC_ERROR_SEVERE;
+    }
+
+    return ret_code;
+}

--- a/Common/Inc/steering/ipc-api.h
+++ b/Common/Inc/steering/ipc-api.h
@@ -11,6 +11,7 @@
 #define IPC_API_H
 
 #include <stdbool.h>
+#include "ipc.h"
 #include "inputs-shared.h"
 
 /*!
@@ -23,7 +24,7 @@ void ipc_api_reset(void);
  *
  * \param callback Callback function to handle each input event.
  */
-void ipc_api_read_and_process_all(void (*callback)(struct InputsSharedEvent ev));
+void ipc_api_read_and_process_all(ipc_process_event_callback callback);
 
 /*!
  * \brief Push an input event to the IPC input queue.
@@ -35,6 +36,6 @@ void ipc_api_read_and_process_all(void (*callback)(struct InputsSharedEvent ev))
  *
  * \return true if the event was successfully pushed, false otherwise.
  */
-bool ipc_api_push_event(struct InputsSharedEvent ev, void (*critical_section_callback)(void));
+bool ipc_api_push_event(struct InputsSharedEvent ev, ipc_critical_section_callback critical_section_callback);
 
 #endif // IPC_API_H

--- a/Common/Inc/steering/ipc.h
+++ b/Common/Inc/steering/ipc.h
@@ -18,6 +18,22 @@
 #define IPC_INPUT_QUEUE_SIZE (64U)
 
 /*!
+ * \brief Callback type for processing input events read from the IPC input queue.
+ *
+ * This callback is invoked for each input event read from the queue, allowing the caller to handle the event as needed.
+ *
+ * \param ev The input event to process.
+ */
+typedef void (*ipc_process_event_callback)(struct InputsSharedEvent ev);
+
+/*!
+ * \brief Callback type for critical section operations when pushing an event to the IPC input queue.
+ *
+ * This callback is executed before updating the index of the input event in the shared memory, allowing the caller to perform any necessary critical section operations before the event is made available to other processes.
+ */
+typedef void (*ipc_critical_section_callback)(void);
+
+/*!
  * \brief Lock-free single-producer single-consumer ring buffer for input events.
  */
 struct IPCInputQueue {

--- a/Common/Src/steering/ipc-api.c
+++ b/Common/Src/steering/ipc-api.c
@@ -15,7 +15,7 @@ void ipc_api_reset(void) {
     ipc_input = (struct IPCInputQueue){ 0 };
 }
 
-void ipc_api_read_and_process_all(void (*callback)(struct InputsSharedEvent ev)) {
+void ipc_api_read_and_process_all(ipc_process_event_callback callback) {
     while (ipc_input.read_idx != ipc_input.write_idx) {
         struct InputsSharedEvent ev =
             ipc_input.events[ipc_input.read_idx];
@@ -27,7 +27,7 @@ void ipc_api_read_and_process_all(void (*callback)(struct InputsSharedEvent ev))
     }
 }
 
-bool ipc_api_push_event(struct InputsSharedEvent ev, void (*critical_section_callback)(void)) {
+bool ipc_api_push_event(struct InputsSharedEvent ev, ipc_critical_section_callback critical_section_callback) {
     uint32_t next = (ipc_input.write_idx + 1) % IPC_INPUT_QUEUE_SIZE;
 
     if (next == ipc_input.read_idx) {


### PR DESCRIPTION
# Purpose
The solely purpose of this PR is to add a POST module to both cores.
Right now the POST module only initializes the various modules of the cores, but will be extended for each module added.

# Overview
Simply added **post** module to both cores. They are the same in term of structure and API, but the working is different based on what they should perform.

I had to modify IPC (and consequently inputs) so that the critical-section callback is now typedef'd, to make the post itself clearer.

# Guidance
Try to build the project (running `pio run -e cm4 -e cm7`) and check the modules for correct working (only by watching them for now).

This PR may close #8 
